### PR TITLE
Avoid reordering newvalue

### DIFF
--- a/compiler/il/OMRAutomaticSymbol.cpp
+++ b/compiler/il/OMRAutomaticSymbol.cpp
@@ -245,6 +245,7 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, T
    {
    TR_ASSERT(kind == TR::newarray     ||
              kind == TR::New          ||
+             kind == TR::newvalue     ||
              kind == TR::anewarray,
              "Invalid kind passed to local object factory");
    TR::AutomaticSymbol * sym  = new (m) TR::AutomaticSymbol(d, s);

--- a/compiler/optimizer/LocalReordering.cpp
+++ b/compiler/optimizer/LocalReordering.cpp
@@ -357,6 +357,7 @@ void TR_LocalReordering::moveStoresEarlierIfRhsAnchored(TR::Block *block, TR::Tr
        !node->getOpCode().isTreeTop() &&
        !node->getOpCode().isCall() &&
        (node->getOpCodeValue() != TR::New) &&
+       (node->getOpCodeValue() != TR::newvalue) &&
        (node->getOpCodeValue() != TR::newarray) &&
        (node->getOpCodeValue() != TR::anewarray) &&
        (node->getOpCodeValue() != TR::multianewarray) &&


### PR DESCRIPTION
Merging escape-analysis changes for value-types.